### PR TITLE
fix: remove .only() to fix CI

### DIFF
--- a/packages/timecrisis/src/scheduler/index.test.ts
+++ b/packages/timecrisis/src/scheduler/index.test.ts
@@ -352,7 +352,7 @@ describe('JobScheduler', () => {
       expect(running.length).toBe(1); // Job should still be running
     });
 
-    it.only('should force stop immediately when force=true', async () => {
+    it('should force stop immediately when force=true', async () => {
       const running: string[] = [];
       const jobDefinition = {
         type: 'test-job',


### PR DESCRIPTION
CI was failing because the usage of `.only()` is forbidden.

See: https://github.com/sandrinodimattia/timecrisis/actions/runs/13049110347/job/36405232524

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/scheduler/index.test.ts > JobScheduler > shutdown behavior > should force stop immediately when force=true
Error: [Vitest] Unexpected .only modifier. Remove it or pass --allowOnly argument to bypass this error
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```